### PR TITLE
Allow Time Shift Strength to be User Configurable

### DIFF
--- a/Processor.cpp
+++ b/Processor.cpp
@@ -83,6 +83,7 @@ Processor::Processor(ProcessorParameters & procParams)
 	rfiScaleBW = procParams.rfiScaleBW;
 	wScaleBW = procParams.wScaleBW;
 	timeShift = procParams.timeShift;
+	timeShiftValue = procParams.timeShiftValue;
 	wCorrMap = procParams.wCorrMap;
 	lssProc = procParams.lssProc;
 
@@ -137,83 +138,20 @@ void Processor::performBGSubtractionMulti(Survey &survey)
 }
 void Processor::performTimeShifting(Survey &survey)
 {
-	double t_int = 0;
-
 	characterizeSurvey(survey);
 
+	double t_int = 0;
 	if (timeShift == true)
 	{
-		/*
-		RCR rcr = RCR(LS_MODE_DL);
-		int centerIndex;
-		bool stop = false;
-		double negation = -1.0;
-		double shift, median = 0, sampling;
-		std::vector<int> checks;
-		std::vector<double> angleHold, angDists, speeds, tempArray, tempWeights, angDistHold, timeHold;
-		std::vector<double> centers, speedTemp;
-		std::vector<std::vector<double> > maxIfftInfo;
-		if (mapType == DAISY)
-		{
-			for (int i = 0; i < scans.size(); i++)
-			{
-				centerIndex = scans[i].getCenter();
-				speeds.push_back((scans[i].getAngDist(centerIndex + 1) - scans[i].getAngDist(centerIndex - 1)) / (scans[i].getTime(centerIndex + 1) - scans[i].getTime(centerIndex - 1)));
-				angDists.push_back((scans[i].getAngDist(centerIndex + 1) - scans[i].getAngDist(centerIndex - 1)) / 2.0);
-			}
-			rcr.performBulkRejection(angDists);
-			sampling = rcr.result.mu;
+		if (timeShiftValue == 0.0) {
+			ProcessorTS procTS = ProcessorTS(scans, mapType, psfFWHM, medianDiffAlongSweeps, scansInRa);
+			t_int = procTS.find_tInt();
 		}
-		else
-		{
-			for (int i = 0; i < scans.size(); i++)
-			{
-				if (scansInRa)
-				{
-					angDistHold = scans[i].getRa();// getAngDist();// STOP CHECK
-				}
-				else
-				{
-					angDistHold = scans[i].getDec();
-				}
-
-				timeHold = scans[i].getTime();
-				for (int j = 1; j < scans[i].getSize(); j++)
-				{
-					speedTemp.push_back((angDistHold[j] - angDistHold[j - 1]) / (timeHold[j] - timeHold[j - 1]));
-				}
-				rcr.performBulkRejection(speedTemp);
-				speeds.push_back(rcr.result.mu);
-				speedTemp.clear();
-			}
-			sampling = medianDiffAlongSweeps;
+		else {
+			t_int = timeShiftValue // user has specified their own time shift value
 		}
-
-		maxIfftInfo = getScanToScanShifts(sampling);
-		shift = calculateShift(maxIfftInfo) / 2.0;
-
-		if (mapType == DAISY)
-		{
-			rcr.performRejection(speeds);
-		}
-		else
-		{
-			rcr.performBulkRejection(speeds);
-		}
-
-
-		t_int = shift / rcr.result.mu;
-
-
-		std::ofstream outputFileAux;
-		outputFileAux.open("TS.txt", std::ios_base::app);
-		outputFileAux << t_int << "\n";
-		outputFileAux.close();
-		*/
-		ProcessorTS procTS = ProcessorTS(scans, mapType, psfFWHM, medianDiffAlongSweeps, scansInRa);
-		t_int = procTS.find_tInt();
+		survey.setTimeShift(t_int);
 	}
-
 
 	Output output;
 	output.printTimeShiftInfo(timeShift, t_int);

--- a/Processor.h
+++ b/Processor.h
@@ -54,19 +54,20 @@ private:
 	bool wCorrMap;
 	bool lssProc;
 
+	double timeShiftValue;
 	double globalMaxDec;
 	double globalMinDec;
 	double globalMaxRa;
 	double globalMinRa;
 	double globalCenterDec;
 	double globalCenterRa;
-	double globalCenterLatProc;   //DYLAN
-	double globalCenterLongProc; //DYLAN
-	double medianLatiMapped;    //DYLAN
-	double medianLongMapped;   //DYLAN
-	bool trackingForEdges;    //DYLAN
+	double globalCenterLatProc;
+	double globalCenterLongProc;
+	double medianLatiMapped;
+	double medianLongMapped;
+	bool trackingForEdges;
 
-	std::string mCoordinate; //DYLAN
+	std::string mCoordinate;
 	std::vector<double> centroidLocations;
 	std::vector<double> standardGaps;
 	std::vector<std::vector<double> > scatter2dLSS;

--- a/Source.cpp
+++ b/Source.cpp
@@ -260,6 +260,7 @@ void setInputProcessingParams(char *argv[], ProcessorParameters &procParams)
 	procParams.bgScaleBW = atof(argv[11]);
 	procParams.rfiScaleBW = atof(argv[12]);
 	procParams.timeShift = atof(argv[5]);
+	procParams.timeShiftValue = atof(argv[22]);
 	procParams.wScaleBW = atof(argv[14]);
 
 	if (photometryOn)

--- a/Survey.cpp
+++ b/Survey.cpp
@@ -2380,9 +2380,15 @@ void Survey::setClassificationsSSS(std::vector<std::vector<std::vector<int> > > 
 {
 	this->classificationsSSS = classVec;
 }
+
 void Survey::setClassificationsLSS(std::vector<std::vector<std::vector<int> > > & classVec)
 {
 	this->classificationsLSS = classVec;
+}
+
+void Survey::setTimeShift(double ts)
+{
+	this->t_int = ts;
 }
 
 //getters

--- a/Survey.h
+++ b/Survey.h
@@ -51,6 +51,7 @@ public:
 	void setScansInRa(bool);
 	void setStandardThetaGap();
 	void setSurveyNumber(int);
+	void setTimeShift(double);
 
 	//getters
 	bool getScanDirection();


### PR DESCRIPTION
## Overview
Allow user to specifiy their own time shifting value. If specified, the processor will use the user's value instead of calculating its own. This is useful for faint sources, like Jupiter.  Perhaps too faint to time-delay correct, but the time-delay is pretty steady

## Related Bug Fix
The timeshift in Survey was being set to 0 regardless of the actual timeshift value being used. This is an unfortunate artifact of how the project ws developed with versions and changes being sent via email rather than using a version control system. I.e., I have zero knowledge of why it was being forced to be 0. I know updatet he time shift value in survey to be the correct value.

This is will only affect the coordinate transformations. If maps appear distorted or their edges are unshapely, this may be the cause and would explain why the time shift was forced to 0. Invesitgate Scan::cosDecTransform and Scan::dynamicCosDecTransform **if** this issue appears.