### PR TITLE
Refine CMake targets and packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(NOT nlohmann_json_FOUND)
 
     FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
     FetchContent_MakeAvailable(json)
+    set(radio_cartographer_bundled_json TRUE)
 endif()
 
 find_package(Threads REQUIRED)
@@ -84,6 +85,13 @@ install(TARGETS radio_cartographer radio-cartographer
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
+
+if(radio_cartographer_bundled_json)
+    install(TARGETS nlohmann_json
+        EXPORT radio_cartographerTargets
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+endif()
 
 install(DIRECTORY include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,101 @@
 cmake_minimum_required(VERSION 3.0)
 project(radio_cartographer)
 
+include(GNUInstallDirs)
+include(FetchContent)
+include(CMakePackageConfigHelpers)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE Debug)
 
-file(GLOB SOURCES "src/*.cpp") 
+option(BUILD_PYTHON_BINDINGS "Build shared library for Python bindings" OFF)
 
-include_directories(include)
+set(radio_cartographer_sources
+    src/Analysis.cpp
+    src/BackgroundCUDA.cpp
+    src/Cartographer.cpp
+    src/Composite.cpp
+    src/Debugger.cpp
+    src/FourtyParser.cpp
+    src/FunctionalForm.cpp
+    src/GBParser.cpp
+    src/Map.cpp
+    src/NonParametric.cpp
+    src/OutputFile.cpp
+    src/Pixel.cpp
+    src/PreProcessor.cpp
+    src/Processor.cpp
+    src/ProcessorRFI.cpp
+    src/ProcessorTS.cpp
+    src/ProcessorThetaGap.cpp
+    src/RCR.cpp
+    src/Scan.cpp
+    src/Survey.cpp
+    src/Tools.cpp
+    src/timer.cpp
+)
 
-add_executable(radio-cartographer ${SOURCES})
+set(radio_cartographer_library_type STATIC)
+if(BUILD_PYTHON_BINDINGS)
+    set(radio_cartographer_library_type SHARED)
+endif()
 
-target_link_libraries(radio-cartographer fftw3 cfitsio CCfits pthread )
+add_library(radio_cartographer ${radio_cartographer_library_type} ${radio_cartographer_sources})
 
-include(FetchContent)
+if(BUILD_PYTHON_BINDINGS)
+    set_target_properties(radio_cartographer PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+endif()
+
+target_include_directories(radio_cartographer
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
 
 FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
 FetchContent_MakeAvailable(json)
-target_link_libraries(radio-cartographer nlohmann_json::nlohmann_json)
+
+find_package(Threads REQUIRED)
+
+target_link_libraries(radio_cartographer
+    PUBLIC
+        fftw3
+        cfitsio
+        CCfits
+        Threads::Threads
+        nlohmann_json::nlohmann_json
+)
+
+add_executable(radio-cartographer src/Source.cpp)
+target_link_libraries(radio-cartographer PRIVATE radio_cartographer)
+
+install(TARGETS radio_cartographer radio-cartographer
+    EXPORT radio_cartographerTargets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT radio_cartographerTargets
+    NAMESPACE radio_cartographer::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/radio_cartographer
+)
+
+configure_package_config_file(
+    cmake/radio_cartographer-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/radio_cartographer-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/radio_cartographer
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/radio_cartographer-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/radio_cartographer
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.0)
 project(radio_cartographer)
 
 include(GNUInstallDirs)
-include(FetchContent)
 include(CMakePackageConfigHelpers)
 
 set(CMAKE_CXX_STANDARD 11)
@@ -56,8 +55,14 @@ target_include_directories(radio_cartographer
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
-FetchContent_MakeAvailable(json)
+find_package(nlohmann_json 3.11 QUIET)
+
+if(NOT nlohmann_json_FOUND)
+    include(FetchContent)
+
+    FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+    FetchContent_MakeAvailable(json)
+endif()
 
 find_package(Threads REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,40 @@ lib /machine:x64 /def:libfftw3l-3.def
 
 ### With Visual Studio
 
-Needs updating
+You can generate a Visual Studio solution with CMake. From a Developer Command Prompt, create a
+build directory (for example, `build`) parallel to the source tree and run:
+
+```
+cmake -S . -B build -G "Visual Studio 17 2022" -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+```
+
+If your dependencies are installed outside the default search paths, add them to
+`CMAKE_PREFIX_PATH`, e.g. `-DCMAKE_PREFIX_PATH="C:/path/to/cfitsio;C:/path/to/fftw"`.
+The generated solution builds the `radio-cartographer` executable and the
+`radio_cartographer` library target.
 
 ### Without Visual Studio
 
-We have a (crude) compile script called `compileStandard.sh` that will compile the project. I often
-dream of writing a `makefile`, but until that day, we must recompile the entire project with the script
-even if we make a one-line change to a single file.
+Use the CMake-based build instead of the old `compileStandard.sh` script. A typical build looks like:
+
+```
+mkdir -p build
+cmake -S . -B build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="/path/to/fftw;/path/to/cfitsio" \
+  -DBUILD_PYTHON_BINDINGS=OFF
+cmake --build build
+```
+
+Key notes:
+
+- The project depends on FFTW3, CFITSIO, CCFITS, pthreads/Win32 threads, and nlohmann_json
+  (automatically fetched if not already available).
+- Set `BUILD_PYTHON_BINDINGS=ON` to build the shared library with position-independent code and
+  default symbol hiding for Python wrappers.
+- Run `cmake --install build --prefix /your/prefix` to install the executable, library, headers,
+  and CMake package config under the chosen prefix (`/usr/local` by default).
 
 ## Running
 

--- a/cmake/radio_cartographer-config.cmake.in
+++ b/cmake/radio_cartographer-config.cmake.in
@@ -3,6 +3,6 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(Threads)
-find_dependency(nlohmann_json)
+find_dependency(nlohmann_json 3.11)
 
 include("${CMAKE_CURRENT_LIST_DIR}/radio_cartographerTargets.cmake")

--- a/cmake/radio_cartographer-config.cmake.in
+++ b/cmake/radio_cartographer-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+find_dependency(nlohmann_json)
+
+include("${CMAKE_CURRENT_LIST_DIR}/radio_cartographerTargets.cmake")


### PR DESCRIPTION
## Summary
- replace globbed sources with an explicit library target owning include paths and dependencies
- link the executable against the new radio_cartographer library and support optional shared builds for Python bindings
- add installation and package configuration generation for downstream consumers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693de0d976a483308486ef12d6821a23)