### PR TITLE
Write processed maps to FITS outputs

### DIFF
--- a/include/Map.h
+++ b/include/Map.h
@@ -1,15 +1,17 @@
 #pragma once
+#include <utility>
 #include <vector>
 #include <string>
 #include "Pixel.h"
 
 enum FitsFile {
-	MAIN_SMALL,
-	MAIN_LARGE,
-	PATH,
-	SCALE,
-	WEIGHT,
-	WEIGHT_TEMP
+        MAIN_SMALL,
+        MAIN_LARGE,
+        PATH,
+        SCALE,
+        WEIGHT,
+        WEIGHT_TEMP,
+        CORRELATION
 };
 
 class Map
@@ -38,7 +40,9 @@ public:
 	void printScanNumberMap();
 	void printIndexNumberMap();
 
-	void printFits(std::string, FitsFile);
+        void printFits(const std::string &fitsName, FitsFile fitsType,
+                       const std::vector<std::pair<std::string, double>> &headerDoubles = {},
+                       const std::vector<std::pair<std::string, std::string>> &headerStrings = {});
 
 	//MAP GETTERS
 	double getMaxDec();


### PR DESCRIPTION
## Summary
- add a CCfits-based Map::printFits that selects map data, handles NaNs, and writes WCS/metadata keys
- add default FITS header builders and update the processing pipeline to emit FITS files instead of .txt maps
- make map dimension access more robust for header generation

## Testing
- cmake -S . -B build *(fails: cannot download nlohmann/json because of 403 proxy restriction)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693dea24e5088330b7d0408f3445e974)